### PR TITLE
bugfix: Substrings can be replaced in longer strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ function chainReplacers(replaceMap) {
   }
 
   return function(inputStream) {
-    return Object.keys(replaceMap).reduce(pipeReplacer, inputStream);
+    return Object.keys(replaceMap)
+      .sort(function (a, b) { return b.length - a.length; })
+      .reduce(pipeReplacer, inputStream);
   }
 }
 


### PR DESCRIPTION
Example:

A folder with two files:

cba.png
ba.png

a file referencing those two files:

```
var file1 = cba.png;
var file2 = ba.png;
```

The replacemap will process those files and replace in the order the keys are in the map (alphabetical it seems). This will replace the substring "ba.png" of file1 with the hashed filename for the ba.png file. Thus giving the wrong url to the file.

I have proposed a solution where the filenames are sorted by length longest to shortest, as this will solve the issue.
